### PR TITLE
Set the API key globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@ A Ruby wrapper around Infoconnect's API
 The idea is to make this a full wrapper. My initial needs are for company so I've
 built that first.
 
+Create a `config/initializers/infoconnect_wrapper.rb` file and set your
+API key there:
+
+```ruby
+InfoconnectWrapper.api_key = "YOUR_API_KEY"
+```
+
 ## Example - Calling by a company name with city and state
 Here's a [Company](http://developer.infoconnect.com/company-object)
-  
+
     find = InfoconnectWrapper::FindCompany.new
-    key = '' #your api key...
-    find.init(key)
     company = find.find_by_name('Infogroup', 'Papillion', 'NE', 'Enhanced')
     #company is a InfoConnectWrapper::Company
     puts company.CorporateSalesVolumeRange
@@ -19,12 +24,7 @@ Here's a [Company](http://developer.infoconnect.com/company-object)
     => "InfoGroup, Inc."
 
 ## Todo's
-- Wrap this all in the currently empty response object so we can put a wrapper around people 
+- Wrap this all in the currently empty response object so we can put a wrapper around people
 - Add some tests
-- Find a way to handle InfoGroup's UpperCase responses without effecting those fields like 
+- Find a way to handle InfoGroup's UpperCase responses without effecting those fields like
 `ACLAttendanceRange` that would couldn't handle a `camelize` and `constantize` transition
-
-
-
-
-

--- a/lib/infoconnect_wrapper.rb
+++ b/lib/infoconnect_wrapper.rb
@@ -1,12 +1,21 @@
 require 'rest-client'
-module InfoconnectWrapper
-  class InfoconnectWrapper
 
+module InfoconnectWrapper
+  class << self
+    attr_accessor :api_key
+  end
+
+  def self.post(url, params={}, headers={})
+    unless api_key ||= @api_key
+      raise StandardError.new('No API key provided. ' \
+        'Set your API key using "InfoconnectWrapper.api_key = <API-KEY>". ')
+    end
+
+    JSON.parse RestClient.post("#{url}?api_key=#{api_key}", params, headers)
   end
 end
 
 require 'infoconnect_wrapper/company'
 require 'infoconnect_wrapper/find_company'
 require 'infoconnect_wrapper/response'
-
 

--- a/lib/infoconnect_wrapper/find_company.rb
+++ b/lib/infoconnect_wrapper/find_company.rb
@@ -1,19 +1,16 @@
 module InfoconnectWrapper
-  require 'rest-client'
   require 'json'
-  
+
   class FindCompany
-    attr_accessor :api_key
-    def init(apikey)
-      self.api_key = apikey 
+    def url
+      "https://api.infoconnect.com/v3/match"
     end
 
-    ##example InfoConnectWrapper::FindCompany.find_by_name('Infogroup', 'Papillion, 'NE', 'Enhanced')
+    # example InfoConnectWrapper::FindCompany.find_by_name('Infogroup', 'Papillion, 'NE', 'Enhanced')
     def find_by_name(name, city, state, resource_type)
-      url = "https://api.infoconnect.com/v3/match?apikey=#{self.api_key}"
-      company = Company.new
       begin
-        response = RestClient.post url,
+        company = Company.new
+        r = InfoconnectWrapper.post url,
           {
           :ResourceType => resource_type,
           :CompanyName => name,
@@ -22,15 +19,15 @@ module InfoconnectWrapper
           :City => city,
           :StateProvince => state
         }, :content_type => :json, :accept => :json
-        r = JSON.parse response
+
         if r["MatchCount"] > 0
           company_to_parse = r["Matches"]["Companies"][0]
           company.init(company_to_parse)
         end
+        company
       rescue => e
         puts e
       end
-      company
     end
   end
 end


### PR DESCRIPTION
This needs to be tested, but saves from setup of the API key on each request. Took this from how Stripe does it in their Ruby gem.
